### PR TITLE
Upgrade Flutter SDK to 3.47.0 and enhance changelog

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: goldenm-software/layrz-actions/.github/actions/check-dart@v1
         with:
-          flutter-version: 3.44.2
+          flutter-version: 3.47.0
           run-tests: false
 
   changelog:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -43,7 +43,7 @@ jobs:
       - uses: flutter-actions/setup-flutter@v4
         with:
           channel: stable
-          version: 3.44.2
+          version: 3.47.0
           cache: true
           cache-sdk: true
           cache-key: ${{ runner.os }}-flutter-${{ hashFiles('pubspec.yaml') }}
@@ -85,8 +85,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # Fetch all history for changelog generation
+        with: { fetch-depth: 0 }
 
       - name: Generate changelog
         id: changelog
@@ -125,15 +124,14 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
 
       - name: Setup Flutter
         uses: flutter-actions/setup-flutter@v4
         with:
           channel: stable
-          version: 3.44.2
+          version: 3.47.0
           cache: true
           cache-sdk: true
           cache-key: ${{ runner.os }}-flutter-${{ hashFiles('pubspec.yaml') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.0
+
+- Changed the minimum Flutter SDK version to 3.47.0 and Dart SDK version to 3.13.0.
+- Adjusted and reviewed to not depend of any material dependency, now this package is design system agnostic.
+
 ## 1.1.1
 
 - Bump the example app's `layrz_theme` to `^7.6.0` and `layrz_models` to `^3.11.0`, which adopt the renamed `solar*` icon getters so the demo site builds against `layrz_icons` 1.1.x.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 
 Sometimes, you need to use icons in your project, but using a single library? Maybe too boring, using multiple? Well, works but can be a mess. So, we created Layrz Icons, a simple and easy to use icon library, designed to combine multiple libraries in a single one, also adding a mapping object to convert any `IconData` into a string.
 
+## Decouple compatibility
+This library does not depend on any material or cupertino dependency, so you can use it in any design system, like Material, Cupertino, Fluent, etc.
+
 ## Live demo / search
 You can check the icons and search for them on the [https://icons.layrz.com](https://icons.layrz.com)
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,6 +6,13 @@ include: package:flutter_lints/flutter.yaml
 analyzer:
   exclude:
     - lib/src/*.dart
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 formatter:
   page_width: 120

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -6,3 +6,12 @@ linter:
 formatter:
   page_width: 120
   trailing_commas: preserve
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -422,7 +422,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "2.0.0"
   layrz_logging:
     dependency: transitive
     description:
@@ -507,10 +507,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -523,10 +523,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -912,10 +912,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   timezone:
     dependency: transitive
     description:
@@ -1048,10 +1048,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:

--- a/internal/tools/generators.go
+++ b/internal/tools/generators.go
@@ -37,8 +37,10 @@ func GenerateClassEnum(baseDir string, m *AllMappings) error {
 
 	w := func(s string) { f.WriteString(s) }
 
-	w("part of \"../layrz_icons.dart\";\n\n")
 	w("/// This is a auto-generated file. Do not modify it manually.\n\n")
+	w("import 'class.dart';\n")
+	w("import 'family.dart';\n")
+	w("\n")
 	w("class LayrzIconsClasses {\n")
 
 	for _, e := range m.MDI {
@@ -89,8 +91,10 @@ func GenerateIconEnum(baseDir string, m *AllMappings) error {
 
 	w := func(s string) { f.WriteString(s) }
 
-	w("part of \"../layrz_icons.dart\";\n\n")
 	w("/// This is a auto-generated file. Do not modify it manually.\n\n")
+	w("import 'class_enum.dart';\n")
+	w("import 'package:flutter/widgets.dart';\n")
+	w("\n")
 	w("class LayrzIcons {\n")
 
 	for _, e := range m.MDI {
@@ -137,8 +141,10 @@ func GenerateMapping(baseDir string, m *AllMappings) error {
 
 	w := func(s string) { f.WriteString(s) }
 
-	w("part of \"../layrz_icons.dart\";\n\n")
 	w("/// This is a auto-generated file. Do not modify it manually.\n\n")
+	w("import 'class.dart';\n")
+	w("import 'class_enum.dart';\n")
+	w("\n")
 	w("Map<String, LayrzIcon> iconMapping = {\n")
 
 	w("  // Material Design Icons\n")

--- a/lib/layrz_icons.dart
+++ b/lib/layrz_icons.dart
@@ -1,71 +1,7 @@
 library;
 
-import 'package:flutter/widgets.dart';
-
-part 'src/class_enum.dart';
-part 'src/icon_enum.dart';
-part 'src/mapping.dart';
-
-class LayrzIcon {
-  final String name;
-  final int codePoint;
-  final LayrzFamily family;
-
-  const LayrzIcon({
-    required this.name,
-    required this.codePoint,
-    required this.family,
-  });
-
-  // ignore: non_const_argument_for_const_parameter
-  IconData get iconData => IconData(codePoint, fontFamily: family.fontFamily, fontPackage: family.fontPackage);
-}
-
-enum LayrzFamily {
-  materialDesignIcons,
-  fontAwesomeBrands,
-  fontAwesomeSolid,
-  fontAwesomeRegular,
-  solarBold,
-  solarBroken,
-  solarLinear,
-  solarOutline,
-  ;
-
-  String get fontFamily {
-    switch (this) {
-      case LayrzFamily.materialDesignIcons:
-        return 'Material Design Icons';
-      case LayrzFamily.fontAwesomeBrands:
-        return 'FontAwesomeBrands';
-      case LayrzFamily.fontAwesomeSolid:
-        return 'FontAwesomeSolid';
-      case LayrzFamily.fontAwesomeRegular:
-        return 'FontAwesomeRegular';
-      case LayrzFamily.solarBold:
-        return 'SolarBold';
-      case LayrzFamily.solarBroken:
-        return 'SolarBroken';
-      case LayrzFamily.solarLinear:
-        return 'SolarLinear';
-      case LayrzFamily.solarOutline:
-        return 'SolarOutline';
-    }
-  }
-
-  String get fontPackage {
-    switch (this) {
-      case LayrzFamily.materialDesignIcons:
-        return 'flutter_material_design_icons';
-      case LayrzFamily.fontAwesomeBrands:
-      case LayrzFamily.fontAwesomeSolid:
-      case LayrzFamily.fontAwesomeRegular:
-        return 'font_awesome_flutter';
-      case LayrzFamily.solarBold:
-      case LayrzFamily.solarBroken:
-      case LayrzFamily.solarLinear:
-      case LayrzFamily.solarOutline:
-        return 'flutty_solar_icons';
-    }
-  }
-}
+export 'src/class.dart';
+export 'src/family.dart';
+export 'src/class_enum.dart';
+export 'src/icon_enum.dart';
+export 'src/mapping.dart';

--- a/lib/src/class.dart
+++ b/lib/src/class.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/widgets.dart';
+
+import 'family.dart';
+
+class LayrzIcon {
+  final String name;
+  final int codePoint;
+  final LayrzFamily family;
+
+  const LayrzIcon({
+    required this.name,
+    required this.codePoint,
+    required this.family,
+  });
+
+  // ignore: non_const_argument_for_const_parameter
+  IconData get iconData => IconData(codePoint, fontFamily: family.fontFamily, fontPackage: family.fontPackage);
+}

--- a/lib/src/class_enum.dart
+++ b/lib/src/class_enum.dart
@@ -1,6 +1,7 @@
-part of "../layrz_icons.dart";
-
 /// This is a auto-generated file. Do not modify it manually.
+
+import 'class.dart';
+import 'family.dart';
 
 class LayrzIconsClasses {
   static LayrzIcon get mdiAbTesting => LayrzIcon(codePoint: 983497, name: "mdi-ab-testing", family: LayrzFamily.materialDesignIcons);

--- a/lib/src/family.dart
+++ b/lib/src/family.dart
@@ -1,0 +1,48 @@
+enum LayrzFamily {
+  materialDesignIcons,
+  fontAwesomeBrands,
+  fontAwesomeSolid,
+  fontAwesomeRegular,
+  solarBold,
+  solarBroken,
+  solarLinear,
+  solarOutline,
+  ;
+
+  String get fontFamily {
+    switch (this) {
+      case LayrzFamily.materialDesignIcons:
+        return 'Material Design Icons';
+      case LayrzFamily.fontAwesomeBrands:
+        return 'FontAwesomeBrands';
+      case LayrzFamily.fontAwesomeSolid:
+        return 'FontAwesomeSolid';
+      case LayrzFamily.fontAwesomeRegular:
+        return 'FontAwesomeRegular';
+      case LayrzFamily.solarBold:
+        return 'SolarBold';
+      case LayrzFamily.solarBroken:
+        return 'SolarBroken';
+      case LayrzFamily.solarLinear:
+        return 'SolarLinear';
+      case LayrzFamily.solarOutline:
+        return 'SolarOutline';
+    }
+  }
+
+  String get fontPackage {
+    switch (this) {
+      case LayrzFamily.materialDesignIcons:
+        return 'flutter_material_design_icons';
+      case LayrzFamily.fontAwesomeBrands:
+      case LayrzFamily.fontAwesomeSolid:
+      case LayrzFamily.fontAwesomeRegular:
+        return 'font_awesome_flutter';
+      case LayrzFamily.solarBold:
+      case LayrzFamily.solarBroken:
+      case LayrzFamily.solarLinear:
+      case LayrzFamily.solarOutline:
+        return 'flutty_solar_icons';
+    }
+  }
+}

--- a/lib/src/icon_enum.dart
+++ b/lib/src/icon_enum.dart
@@ -1,6 +1,7 @@
-part of "../layrz_icons.dart";
-
 /// This is a auto-generated file. Do not modify it manually.
+
+import 'class_enum.dart';
+import 'package:flutter/widgets.dart';
 
 class LayrzIcons {
   static IconData get mdiAbTesting => LayrzIconsClasses.mdiAbTesting.iconData;

--- a/lib/src/mapping.dart
+++ b/lib/src/mapping.dart
@@ -1,6 +1,7 @@
-part of "../layrz_icons.dart";
-
 /// This is a auto-generated file. Do not modify it manually.
+
+import 'class.dart';
+import 'class_enum.dart';
 
 Map<String, LayrzIcon> iconMapping = {
   // Material Design Icons

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: layrz_icons
 description: "A unified icon package to simplify icon usage."
-version: 1.1.1
+version: 2.0.0
 homepage: https://icons.layrz.com
 repository: https://github.com/goldenm-software/layrz_icons
 
 environment:
-  sdk: ">=3.12.0 <4.0.0"
-  flutter: ">=3.44.0"
+  sdk: ">=3.13.0 <4.0.0"
+  flutter: ">=3.47.0"
 
 dependencies:
   flutter: { sdk: flutter }


### PR DESCRIPTION
Update the Flutter SDK version to 3.47.0, adjust dependencies accordingly, and enhance the changelog to reflect changes in the package's design system compatibility. The package now supports a broader range of design systems by decoupling from material dependencies.